### PR TITLE
Complete ZeroMQ's changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,7 +248,19 @@ if let Ok(mut zeromq) = zeromq {
 Example of this new API:
 
 ```rs
+use wmjtyd_libstock::message::nanomsg::NanomsgSubscriber;
+use wmjtyd_libstock::message::traits::{Connect, Read, Subscribe};
 
+let nanomsg = NanomsgSubscriber::new();
+
+if let Ok(mut nanomsg) = nanomsg {
+    nanomsg.connect("ipc:///tmp/cl-nanomsg-new-api-r.ipc").ok();
+    nanomsg.subscribe(b"").ok();
+
+    let mut buf = [0; 12];
+    nanomsg.read_exact(&mut buf).ok();
+    assert_eq!(b"Hello World!", &buf);
+}
 ```
 
 **Migrate `zeromq` readers**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,11 +150,11 @@ Some notable big changes to migrate your codebase:
 #### `message`
 
 Though we reshaped and rewrote all the message modules,
-there is not really big changes for users.
+there are not really big changes for users.
 
 **Migrate `nanomsg` writers**
 
-Assuming you used to have such a code:
+Assuming you used to write this way:
 
 ```rs
 use std::io::Write;
@@ -167,7 +167,7 @@ if let Ok(mut nanomsg) = nanomsg {
 }
 ```
 
-First, update your `Nanomsg` import to `NanomsgPublisher`.
+First, update your `Nanomsg` imports to `NanomsgPublisher`.
 We have separated `Nanomsg` to `NanomsgPublisher` and `NanomsgSubscriber`,
 which implementing the corresponding `Publisher` and `Subscriber`:
 
@@ -176,8 +176,8 @@ use wmjtyd_libstock::message::nanomsg::NanomsgPublisher;
 ```
 
 And then, construct your `NanomsgPublisher`. **Note that no any
-additional parameter will pass it this construction**, and we
-will bind our address later.
+additional parameter need to pass in this construction**. For address,
+we will bind our address in another function later.
 
 ```rs
 let nanomsg = NanomsgPublisher::new();
@@ -245,7 +245,7 @@ if let Ok(mut zeromq) = zeromq {
 **Migrate `nanomsg` readers**
 
 *WIP*. Really similar to what we did in writers.
-Example of this new API:
+Example of this new synchronous API:
 
 ```rs
 use wmjtyd_libstock::message::nanomsg::NanomsgSubscriber;
@@ -266,7 +266,8 @@ if let Ok(mut nanomsg) = nanomsg {
 **Migrate `zeromq` readers**
 
 *WIP*. All of the APIs are followed our new rule and
-thus the logic is just the same. Example of this new API:
+thus the logic is just the same. Example of this new
+asynchronous API:
 
 ```rs
 use wmjtyd_libstock::message::zeromq::ZeromqSubscriber;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,7 +212,7 @@ use tokio::io::AsyncWriteExt;  // or use wmjtyd_libstock::message::traits::Async
 }
 ```
 
-The full example:
+The full synchronous example:
 
 ```rs
 use wmjtyd_libstock::message::nanomsg::NanomsgPublisher;
@@ -228,17 +228,17 @@ if let Ok(mut nanomsg) = nanomsg {
 
 **Migrate `zeromq` writers**
 
-Just like `nanomsg`, but use `zeromq::ZeromqPublisher`. Example:
+Just like `nanomsg`, but use `zeromq::ZeromqPublisher`. Asynchronous Example:
 
 ```rs
+use wmjtyd_libstock::message::traits::{AsyncWriteExt, Bind};
 use wmjtyd_libstock::message::zeromq::ZeromqPublisher;
-use wmjtyd_libstock::message::traits::{Bind, Write};
 
 let zeromq = ZeromqPublisher::new();
 
 if let Ok(mut zeromq) = zeromq {
-    zeromq.bind("ipc:///tmp/cl-zeromq-new-api-w.ipc").ok();
-    zeromq.write_all(b"Hello World!").ok();
+    zeromq.bind("ipc:///tmp/cl-zeromq-new-api-w-a.ipc").ok();
+    zeromq.write_all(b"Hello World!").await.ok();
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,7 +269,19 @@ if let Ok(mut nanomsg) = nanomsg {
 thus the logic is just the same. Example of this new API:
 
 ```rs
+use wmjtyd_libstock::message::zeromq::ZeromqSubscriber;
+use wmjtyd_libstock::message::traits::{Connect, AsyncReadExt, Subscribe};
 
+let zeromq = ZeromqSubscriber::new();
+
+if let Ok(mut zeromq) = zeromq {
+    zeromq.connect("ipc:///tmp/cl-zeromq-new-api-r.ipc").ok();
+    zeromq.subscribe(b"").ok();
+
+    let mut buf = [0; 12];
+    zeromq.read_exact(&mut buf).await.ok();
+    assert_eq!(b"Hello World!", &buf);
+}
 ```
 
 ### 0.4.0 – Breaking Changes

--- a/src/message.rs
+++ b/src/message.rs
@@ -107,3 +107,160 @@ pub enum MessageError {
 }
 
 pub type MessageResult<T> = Result<T, MessageError>;
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+
+    use super::traits::{
+        AsyncPublisher,
+        AsyncSubscriber,
+        Bind,
+        Connect,
+        Subscribe,
+        SyncPublisher,
+        SyncSubscriber,
+    };
+
+    fn abstract_write_function(
+        mut publisher: impl Bind<Err = impl Debug> + SyncPublisher,
+        addr: &str,
+    ) {
+        publisher.bind(addr).expect("failed to bind");
+
+        loop {
+            publisher
+                .write_all(b"TEST Hello, World")
+                .expect("failed to write");
+            publisher.flush().expect("failed to flush")
+        }
+    }
+
+    async fn abstract_async_write_function(
+        mut publisher: impl Bind<Err = impl Debug> + AsyncPublisher,
+        addr: &str,
+    ) {
+        use tokio::io::AsyncWriteExt;
+
+        publisher.bind(addr).expect("failed to bind");
+
+        let mut publisher = Box::pin(publisher);
+
+        loop {
+            publisher
+                .write_all(b"TEST Hello, World")
+                .await
+                .expect("failed to write");
+            publisher.flush().await.expect("failed to flush");
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+    }
+
+    async fn abstract_async_read_function<E, S>(mut subscriber: S, addr: &str)
+    where
+        E: Debug,
+        S: Connect<Err = E> + AsyncSubscriber<Err = E> + Subscribe<Err = E>,
+    {
+        use futures::StreamExt;
+        use tokio::io::AsyncReadExt;
+
+        subscriber.connect(addr).expect("failed to connect");
+        subscriber.subscribe(b"TEST").expect("failed to subscribe");
+
+        let mut subscriber = Box::pin(subscriber);
+
+        let response = subscriber.next().await;
+        // let mut buf = [0u8; 17];
+        // let message_size = subscriber.read(&mut buf).await.expect("failed to read");
+
+        assert_eq!(response.unwrap().unwrap(), b"TEST Hello, World");
+        // assert_eq!(
+        //     &buf,
+        //     b"TEST Hello, World"
+        // );
+        // assert_eq!(
+        //     message_size,
+        //     17
+        // )
+    }
+
+    fn abstract_read_function<S, E>(mut subscriber: S, addr: &str)
+    where
+        E: Debug,
+        S: Connect<Err = E> + SyncSubscriber<Err = E> + Subscribe<Err = E>,
+    {
+        subscriber.connect(addr).expect("failed to connect");
+        subscriber.subscribe(b"TEST").expect("failed to subscribe");
+
+        let message = subscriber.next().expect("no data inside");
+        assert_eq!(
+            message.expect("data receiving failed"),
+            b"TEST Hello, World"
+        );
+    }
+
+    mod nanomsg {
+        use super::super::nanomsg::{NanomsgPublisher, NanomsgSubscriber};
+        use super::*;
+
+        #[test]
+        fn sync_v() {
+            const IPC_ADDR: &str = "ipc:///tmp/libstock-nanomsg-test.ipc";
+            let publisher = NanomsgPublisher::new().expect("failed to create publisher");
+            let subscriber = NanomsgSubscriber::new().expect("failed to create subscriber");
+
+            std::thread::spawn(move || abstract_write_function(publisher, IPC_ADDR));
+            std::thread::spawn(move || abstract_read_function(subscriber, IPC_ADDR))
+                .join()
+                .unwrap();
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn async_v() {
+            const IPC_ADDR: &str = "ipc:///tmp/libstock-nanomsg-test-async.ipc";
+            let publisher = NanomsgPublisher::new().expect("failed to create publisher");
+            let subscriber = NanomsgSubscriber::new().expect("failed to create subscriber");
+
+            let publisher_thread =
+                tokio::task::spawn(abstract_async_write_function(publisher, IPC_ADDR));
+            tokio::task::spawn(abstract_async_read_function(subscriber, IPC_ADDR))
+                .await
+                .unwrap();
+
+            publisher_thread.abort();
+        }
+    }
+
+    mod zeromq {
+        use super::super::zeromq::{ZeromqPublisher, ZeromqSubscriber};
+        use super::*;
+
+        #[test]
+        fn sync() {
+            const IPC_ADDR: &str = "ipc:///tmp/libstock-zeromq-test.ipc";
+            let publisher = ZeromqPublisher::new().expect("failed to create publisher");
+            let subscriber = ZeromqSubscriber::new().expect("failed to create subscriber");
+
+            std::thread::spawn(move || abstract_write_function(publisher, IPC_ADDR));
+            std::thread::spawn(move || abstract_read_function(subscriber, IPC_ADDR))
+                .join()
+                .unwrap();
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn async_v() {
+            const IPC_ADDR: &str = "ipc:///tmp/libstock-zeromq-test-async.ipc";
+
+            let publisher = ZeromqPublisher::new().expect("failed to create publisher");
+            let subscriber = ZeromqSubscriber::new().expect("failed to create subscriber");
+
+            let publisher_thread =
+                tokio::task::spawn(abstract_async_write_function(publisher, IPC_ADDR));
+            tokio::task::spawn(abstract_async_read_function(subscriber, IPC_ADDR))
+                .await
+                .unwrap();
+
+            publisher_thread.abort();
+        }
+    }
+}

--- a/src/message.rs
+++ b/src/message.rs
@@ -171,14 +171,8 @@ mod tests {
         let mut buf = [0u8; 17];
         let message_size = subscriber.read(&mut buf).await.expect("failed to read");
 
-        assert_eq!(
-            &buf,
-            b"TEST Hello, World"
-        );
-        assert_eq!(
-            message_size,
-            17
-        )
+        assert_eq!(&buf, b"TEST Hello, World");
+        assert_eq!(message_size, 17)
     }
 
     async fn abstract_async_stream_function<E, S>(mut subscriber: S, addr: &str)
@@ -193,7 +187,9 @@ mod tests {
 
         let mut subscriber = Box::pin(subscriber);
 
-        let response = subscriber.next().await
+        let response = subscriber
+            .next()
+            .await
             .expect("no data inside")
             .expect("data receiving failed");
 
@@ -209,13 +205,11 @@ mod tests {
         subscriber.subscribe(b"TEST").expect("failed to subscribe");
 
         let mut buf = [0; 17];
-        subscriber.read_exact(&mut buf)
+        subscriber
+            .read_exact(&mut buf)
             .expect("data retriving failed");
 
-        assert_eq!(
-            &buf[..],
-            b"TEST Hello, World"
-        );
+        assert_eq!(&buf[..], b"TEST Hello, World");
     }
 
     fn abstract_iter_function<S, E>(mut subscriber: S, addr: &str)
@@ -243,7 +237,12 @@ mod tests {
         ) => {
             #[test]
             fn $func_name() {
-                const IPC_ADDR: &str = concat!("ipc:///tmp/libstock_", stringify!($read_abs), stringify!($subscriber), ".ipc");
+                const IPC_ADDR: &str = concat!(
+                    "ipc:///tmp/libstock_",
+                    stringify!($read_abs),
+                    stringify!($subscriber),
+                    ".ipc"
+                );
                 let publisher = $publisher::new().expect("failed to create publisher");
                 let subscriber = $subscriber::new().expect("failed to create subscriber");
 
@@ -263,7 +262,12 @@ mod tests {
         ) => {
             #[tokio::test(flavor = "multi_thread")]
             async fn $func_name() {
-                const IPC_ADDR: &str = concat!("ipc:///tmp/libstock_", stringify!($read_abs), stringify!($subscriber), ".ipc");
+                const IPC_ADDR: &str = concat!(
+                    "ipc:///tmp/libstock_",
+                    stringify!($read_abs),
+                    stringify!($subscriber),
+                    ".ipc"
+                );
                 let publisher = $publisher::new().expect("failed to create publisher");
                 let subscriber = $subscriber::new().expect("failed to create subscriber");
 

--- a/src/message/nanomsg.rs
+++ b/src/message/nanomsg.rs
@@ -60,3 +60,52 @@ pub enum NanomsgError {
 
 /// The result type of [`Nanomsg`](self).
 pub type NanomsgResult<T> = Result<T, NanomsgError>;
+
+#[cfg(test)]
+mod tests {
+    use crate as wmjtyd_libstock;
+
+    mod changelog_0_4_0 {
+        use super::*;
+
+        /**
+        API in old days:
+
+        ```compile_fail
+        use std::io::Write;
+        use wmjtyd_libstock::message::nanomsg::{Nanomsg, NanomsgProtocol};
+
+        let nanomsg = Nanomsg::new("ipc:///tmp/cl-nanomsg-old-api-w.ipc", NanomsgProtocol::Pub);
+
+        if let Ok(mut nanomsg) = nanomsg {
+            nanomsg.write_all(b"Hello World!").ok();
+        }
+        ```
+        */
+        #[test]
+        fn migrate_to_new_api_write() {
+            use wmjtyd_libstock::message::nanomsg::NanomsgPublisher;
+            use wmjtyd_libstock::message::traits::{Bind, Write};
+
+            let nanomsg = NanomsgPublisher::new();
+
+            if let Ok(mut nanomsg) = nanomsg {
+                nanomsg.bind("ipc:///tmp/cl-nanomsg-new-api-w.ipc").ok();
+                nanomsg.write_all(b"Hello World!").ok();
+            }
+        }
+
+        #[tokio::test]
+        async fn migrate_to_new_api_write_async() {
+            use wmjtyd_libstock::message::nanomsg::NanomsgPublisher;
+            use wmjtyd_libstock::message::traits::{Bind, AsyncWriteExt};
+
+            let nanomsg = NanomsgPublisher::new();
+
+            if let Ok(mut nanomsg) = nanomsg {
+                nanomsg.bind("ipc:///tmp/cl-nanomsg-new-api-w.ipc").ok();
+                nanomsg.write_all(b"Hello World!").await.ok();
+            }
+        }
+    }
+}

--- a/src/message/nanomsg.rs
+++ b/src/message/nanomsg.rs
@@ -162,7 +162,7 @@ mod tests {
             /* NOT IN DOC -- END -- Start a thread to write. */
 
             use wmjtyd_libstock::message::nanomsg::NanomsgSubscriber;
-            use wmjtyd_libstock::message::traits::{Connect, AsyncReadExt, Subscribe};
+            use wmjtyd_libstock::message::traits::{AsyncReadExt, Connect, Subscribe};
 
             let nanomsg = NanomsgSubscriber::new();
 

--- a/src/message/traits.rs
+++ b/src/message/traits.rs
@@ -3,7 +3,7 @@
 pub use std::io::{Read, Write};
 
 pub use futures::Stream;
-pub use tokio::io::{AsyncRead, AsyncWrite, AsyncReadExt, AsyncWriteExt};
+pub use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 /// The trait for implementing the subscriber of a topic.
 pub trait Subscribe {

--- a/src/message/traits.rs
+++ b/src/message/traits.rs
@@ -3,7 +3,7 @@
 pub use std::io::{Read, Write};
 
 pub use futures::Stream;
-pub use tokio::io::{AsyncRead, AsyncWrite};
+pub use tokio::io::{AsyncRead, AsyncWrite, AsyncReadExt, AsyncWriteExt};
 
 /// The trait for implementing the subscriber of a topic.
 pub trait Subscribe {

--- a/src/message/zeromq.rs
+++ b/src/message/zeromq.rs
@@ -89,5 +89,71 @@ mod tests {
                 zeromq.write_all(b"Hello World!").await.ok();
             }
         }
+
+        #[test]
+        fn new_read_example() {
+            /* NOT IN DOC -- BEGIN -- Start a thread to write. */
+            std::thread::spawn(|| {
+                use wmjtyd_libstock::message::traits::{Bind, Write};
+                use wmjtyd_libstock::message::zeromq::ZeromqPublisher;
+
+                let zeromq = ZeromqPublisher::new();
+
+                if let Ok(mut zeromq) = zeromq {
+                    zeromq.bind("ipc:///tmp/cl-zeromq-new-api-r.ipc").ok();
+                    loop {
+                        zeromq.write_all(b"Hello World!").ok();
+                    }
+                }
+            });
+            /* NOT IN DOC -- END -- Start a thread to write. */
+
+            use wmjtyd_libstock::message::traits::{Connect, Read, Subscribe};
+            use wmjtyd_libstock::message::zeromq::ZeromqSubscriber;
+
+            let zeromq = ZeromqSubscriber::new();
+
+            if let Ok(mut zeromq) = zeromq {
+                zeromq.connect("ipc:///tmp/cl-zeromq-new-api-r.ipc").ok();
+                zeromq.subscribe(b"").ok();
+
+                let mut buf = [0; 12];
+                zeromq.read_exact(&mut buf).ok();
+                assert_eq!(b"Hello World!", &buf);
+            }
+        }
+
+        #[tokio::test]
+        async fn new_read_async_example() {
+            /* NOT IN DOC -- BEGIN -- Start a thread to write. */
+            std::thread::spawn(|| {
+                use wmjtyd_libstock::message::traits::{Bind, Write};
+                use wmjtyd_libstock::message::zeromq::ZeromqPublisher;
+
+                let zeromq = ZeromqPublisher::new();
+
+                if let Ok(mut zeromq) = zeromq {
+                    zeromq.bind("ipc:///tmp/cl-zeromq-new-api-r.ipc").ok();
+                    loop {
+                        zeromq.write_all(b"Hello World!").ok();
+                    }
+                }
+            });
+            /* NOT IN DOC -- END -- Start a thread to write. */
+
+            use wmjtyd_libstock::message::traits::{AsyncReadExt, Connect, Subscribe};
+            use wmjtyd_libstock::message::zeromq::ZeromqSubscriber;
+
+            let zeromq = ZeromqSubscriber::new();
+
+            if let Ok(mut zeromq) = zeromq {
+                zeromq.connect("ipc:///tmp/cl-zeromq-new-api-r.ipc").ok();
+                zeromq.subscribe(b"").ok();
+
+                let mut buf = [0; 12];
+                zeromq.read_exact(&mut buf).await.ok();
+                assert_eq!(b"Hello World!", &buf);
+            }
+        }
     }
 }

--- a/src/message/zeromq.rs
+++ b/src/message/zeromq.rs
@@ -57,7 +57,6 @@ pub enum ZeromqError {
 /// The result type of [`Zeromq`](self).
 pub type ZeromqResult<T> = Result<T, ZeromqError>;
 
-
 #[cfg(test)]
 mod tests {
     use crate as wmjtyd_libstock;
@@ -67,14 +66,27 @@ mod tests {
 
         #[test]
         fn migrate_to_new_api_write() {
-            use wmjtyd_libstock::message::zeromq::ZeromqPublisher;
             use wmjtyd_libstock::message::traits::{Bind, Write};
-            
+            use wmjtyd_libstock::message::zeromq::ZeromqPublisher;
+
             let zeromq = ZeromqPublisher::new();
-            
+
             if let Ok(mut zeromq) = zeromq {
                 zeromq.bind("ipc:///tmp/cl-zeromq-new-api-w.ipc").ok();
                 zeromq.write_all(b"Hello World!").ok();
+            }
+        }
+
+        #[tokio::test]
+        async fn migrate_to_new_api_write_async() {
+            use wmjtyd_libstock::message::traits::{AsyncWriteExt, Bind};
+            use wmjtyd_libstock::message::zeromq::ZeromqPublisher;
+
+            let zeromq = ZeromqPublisher::new();
+
+            if let Ok(mut zeromq) = zeromq {
+                zeromq.bind("ipc:///tmp/cl-zeromq-new-api-w-a.ipc").ok();
+                zeromq.write_all(b"Hello World!").await.ok();
             }
         }
     }

--- a/src/message/zeromq.rs
+++ b/src/message/zeromq.rs
@@ -56,3 +56,26 @@ pub enum ZeromqError {
 
 /// The result type of [`Zeromq`](self).
 pub type ZeromqResult<T> = Result<T, ZeromqError>;
+
+
+#[cfg(test)]
+mod tests {
+    use crate as wmjtyd_libstock;
+
+    mod changelog_0_4_0 {
+        use super::*;
+
+        #[test]
+        fn migrate_to_new_api_write() {
+            use wmjtyd_libstock::message::zeromq::ZeromqPublisher;
+            use wmjtyd_libstock::message::traits::{Bind, Write};
+            
+            let zeromq = ZeromqPublisher::new();
+            
+            if let Ok(mut zeromq) = zeromq {
+                zeromq.bind("ipc:///tmp/cl-zeromq-new-api-w.ipc").ok();
+                zeromq.write_all(b"Hello World!").ok();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- test(message): add sync and async test
- feat(message/traits): expose Async*Ext
- docs(changelog): add migration guide of message
- refactor(changelog): use async example for zeromq
- docs(changelog): nanomsg's new reader api
- test(message): cover more tests
- docs(changelog): Migrate `zeromq` readers


